### PR TITLE
2022.04.0 base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,27 @@
-FROM docker.io/library/ubuntu:jammy
+FROM docker.io/library/ubuntu:jammy AS builder
+
+WORKDIR /tmp
 
 RUN set -ex; \
-    useradd -m -u 9999 codewarrior; \
-    mkdir -p /workspace; \
-    chown -R codewarrior: /workspace;
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      wget ca-certificates curl build-essential unzip; \
+    wget https://github.com/coq/platform/archive/refs/tags/2022.04.0.tar.gz; \
+    tar xvf 2022.04.0.tar.gz; \
+    rm -vf 2022.04.0.tar.gz;
+
+WORKDIR /tmp/platform-2022.04.0
+
+ENV OPAMROOT=/opt/coq \
+    OPAMYES=1 \
+    OCAML_VERSION=default \
+    COQ_PLATFORM_EXTENT=b \
+    COQ_PLATFORM_PACKAGE_PICK_FILE=package_picks/package-pick-8.15~2022.04.sh \
+    COQ_PLATFORM_PARALLEL=p \
+    COQ_PLATFORM_JOBS=4 \
+    COQ_PLATFORM_SET_SWITCH=y
 
 RUN set -ex; \
-    apt-get update;
-
-USER codewarrior
-
-WORKDIR /workspace
-
-RUN set -ex; \
-    cd /workspace;
+    echo "" > stdin; \
+    echo "d" >> stdin; \
+    ./coq_platform_make.sh < stdin;

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,3 +25,39 @@ RUN set -ex; \
     echo "" > stdin; \
     echo "d" >> stdin; \
     ./coq_platform_make.sh < stdin;
+
+ENV OPAM_SWITCH_NAME=__coq-platform.2022.04.0~8.15~2022.04
+ENV OPAM_SWITCH_PREFIX=/opt/coq/$OPAM_SWITCH_NAME
+ENV CAML_LD_LIBRARY_PATH=$OPAM_SWITCH_PREFIX/lib/stublibs:$OPAM_SWITCH_PREFIX/lib/ocaml/stublibs:$OPAM_SWITCH_PREFIX/lib/ocaml \
+    OCAML_TOPLEVEL_PATH=$OPAM_SWITCH_PREFIX/lib/stublibs/lib/toplevel \
+    PATH=$OPAM_SWITCH_PREFIX/bin:$PATH
+
+RUN set -ex; \
+    cd /opt; \
+    wget https://github.com/codewars/coq_codewars/archive/refs/tags/v2.0.0.tar.gz; \
+    tar xvf v2.0.0.tar.gz; \
+    rm v2.0.0.tar.gz; \
+    cd coq_codewars-2.0.0; \
+    coq_makefile -f _CoqProject -o Makefile; \
+    make;
+
+FROM docker.io/library/ubuntu:jammy
+
+RUN useradd -m codewarrior
+COPY --from=builder /opt/coq /opt/coq
+COPY --from=builder /opt/coq_codewars-2.0.0/src /opt/coq_codewars-2.0.0/src
+COPY --from=builder /opt/coq_codewars-2.0.0/theories/Loader.vo /opt/coq_codewars-2.0.0/theories/Loader.vo
+RUN set -ex; \
+    mkdir -p /workspace; \
+    chown -R codewarrior: /workspace;
+
+USER codewarrior
+ENV OPAM_SWITCH_NAME=__coq-platform.2022.04.0~8.15~2022.04
+ENV OPAM_SWITCH_PREFIX=/opt/coq/$OPAM_SWITCH_NAME
+ENV USER=codewarrior \
+    HOME=/home/codewarrior \
+    CAML_LD_LIBRARY_PATH=$OPAM_SWITCH_PREFIX/lib/stublibs:$OPAM_SWITCH_PREFIX/lib/ocaml/stublibs:$OPAM_SWITCH_PREFIX/lib/ocaml \
+    OCAML_TOPLEVEL_PATH=$OPAM_SWITCH_PREFIX/lib/stublibs/lib/toplevel \
+    PATH=$OPAM_SWITCH_PREFIX/bin:$PATH
+
+WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN set -ex; \
     cd /opt; \
     wget https://github.com/codewars/coq_codewars/archive/refs/tags/v2.0.0.tar.gz; \
     tar xvf v2.0.0.tar.gz; \
-    rm v2.0.0.tar.gz; \
+    rm -vf v2.0.0.tar.gz; \
     cd coq_codewars-2.0.0; \
     coq_makefile -f _CoqProject -o Makefile; \
     make;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,80 +1,16 @@
-FROM alpine:3.11 AS builder
-
-RUN apk add --no-cache \
-      bash \
-      bubblewrap \
-      build-base \
-      ca-certificates \
-      coreutils \
-      curl \
-      git \
-      m4 \
-      ncurses-dev \
-      opam \
-      ocaml \
-      ocaml-compiler-libs \
-      patch \
-      rsync \
-      tar \
-      xz \
-    ;
-
-# Disable sandboxing
-RUN set -ex; \
-    echo 'wrap-build-commands: []' > ~/.opamrc; \
-    echo 'wrap-install-commands: []' >> ~/.opamrc; \
-    echo 'wrap-remove-commands: []' >> ~/.opamrc; \
-    echo 'required-tools: []' >> ~/.opamrc;
-
-ENV OPAMROOT=/opt/coq \
-    OPAMYES=1 \
-    OCAML_VERSION=default
+FROM docker.io/library/ubuntu:jammy
 
 RUN set -ex; \
-    mkdir -p /opt/coq; \
-    opam init --no-setup -j 4; \
-    opam repo add coq-released http://coq.inria.fr/opam/released; \
-    opam install -j 4 coq.8.12.0; \
-    opam pin add coq 8.12.0; \
-    opam install \
-      -j 4 \
-      coq-equations.1.2.3+8.12 \
-      coq-mathcomp-ssreflect.1.11.0 \
-    ;
-
-ENV OPAM_SWITCH_PREFIX=/opt/coq/default
-ENV CAML_LD_LIBRARY_PATH=$OPAM_SWITCH_PREFIX/lib/stublibs:$OPAM_SWITCH_PREFIX/lib/ocaml/stublibs:$OPAM_SWITCH_PREFIX/lib/ocaml \
-    OCAML_TOPLEVEL_PATH=$OPAM_SWITCH_PREFIX/lib/stublibs/lib/toplevel \
-    PATH=$OPAM_SWITCH_PREFIX/bin:$PATH
-RUN set -ex; \
-    cd /opt; \
-    git clone --depth 1 --branch v2.0.0 https://github.com/codewars/coq_codewars.git; \
-    cd coq_codewars; \
-    coq_makefile -f _CoqProject -o Makefile; \
-    make;
-
-
-FROM alpine:3.11
-
-RUN adduser -D codewarrior
-RUN apk add --no-cache \
-      build-base \
-      ncurses-dev \
-      ocaml \
-    ;
-COPY --from=builder /opt/coq /opt/coq
-COPY --from=builder /opt/coq_codewars/src /opt/coq_codewars/src
-COPY --from=builder /opt/coq_codewars/theories/Loader.vo /opt/coq_codewars/theories/Loader.vo
-RUN set -ex; \
+    useradd -m -u 9999 codewarrior; \
     mkdir -p /workspace; \
-    chown codewarrior:codewarrior /workspace;
+    chown -R codewarrior: /workspace;
+
+RUN set -ex; \
+    apt-get update;
 
 USER codewarrior
-ENV OPAM_SWITCH_PREFIX=/opt/coq/default
-ENV USER=codewarrior \
-    HOME=/home/codewarrior \
-    CAML_LD_LIBRARY_PATH=$OPAM_SWITCH_PREFIX/lib/stublibs:$OPAM_SWITCH_PREFIX/lib/ocaml/stublibs:$OPAM_SWITCH_PREFIX/lib/ocaml \
-    OCAML_TOPLEVEL_PATH=$OPAM_SWITCH_PREFIX/lib/stublibs/lib/toplevel \
-    PATH=$OPAM_SWITCH_PREFIX/bin:$PATH
 
 WORKDIR /workspace
+
+RUN set -ex; \
+    cd /workspace;

--- a/README.md
+++ b/README.md
@@ -5,17 +5,13 @@ Container image for Coq used by CodeRunner.
 ## Usage
 
 ```bash
-W=/workspace
-# Create container
-C=$(docker container create --rm -w $W ghcr.io/codewars/coq:latest sh -c "coqc Solution.v && coqc -I /opt/coq_codewars/src -Q /opt/coq_codewars/theories CW SolutionTest.v")
+$ ./bin/run
+```
 
-# Copy files from the current directory
-# ./Solution.v
-# ./SolutionTest.v
-docker container cp ./. $C:$W
+You can specify the container engine through the variable `CONTAINER_ENGINE` (default: `docker`). For example, with Podman:
 
-# Start
-docker container start --attach $C
+```bash
+$ CONTAINER_ENGINE=podman ./bin/run
 ```
 
 ## Building

--- a/bin/run
+++ b/bin/run
@@ -1,14 +1,21 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -eu
 
+if [ -z "${CONTAINER_ENGINE:+x}" ]; then
+	CONTAINER_ENGINE=docker
+fi
+
 W=/workspace
-# Create container
-C=$(docker container create --rm -w $W ghcr.io/codewars/coq:latest sh -c "coqc Solution.v && coqc -I /opt/coq_codewars/src -Q /opt/coq_codewars/theories CW SolutionTest.v")
 
-# Copy files from the current directory
-# example/Solution.v
-# example/SolutionTest.v
-docker container cp examples/${1:-passing}/. $C:$W
+for example in $(ls examples); do
+	# Create container
+	C=$($CONTAINER_ENGINE container create --rm -w $W ghcr.io/codewars/coq:latest sh -c "coqc Solution.v && coqc -I /opt/coq_codewars-2.0.0/src -R /opt/coq_codewars-2.0.0/theories CW SolutionTest.v")
 
-# Run tests
-docker container start --attach $C
+	# Copy files from the current directory
+	# example/Solution.v
+	# example/SolutionTest.v
+	$CONTAINER_ENGINE container cp examples/$example/. $C:$W
+	
+	# Run tests
+	$CONTAINER_ENGINE container start --attach $C || true
+done

--- a/examples/failing/Solution.v
+++ b/examples/failing/Solution.v
@@ -1,1 +1,1 @@
-Theorem thm4 : 1 = 1. Proof. reflexivity. Qed.
+Theorem thm4 : 1 = 1. Proof. Admitted.

--- a/examples/failing/SolutionTest.v
+++ b/examples/failing/SolutionTest.v
@@ -1,16 +1,9 @@
-Require Import Solution.
+Require Solution.
+From CW Require Import Loader.
 
-Theorem thm1 : 1 = 1 + 0. Proof. admit. Admitted.
-Print Assumptions thm1.
-
-Parameter thm2 : 1 + 0 = 0 + 1.
-Print Assumptions thm2.
-
-Theorem thm3 : 1 = 0 + 1. Proof. rewrite <- thm2. exact thm1. Qed.
-Print Assumptions thm3.
-
-Theorem thm4_check : 1 = 1.
-Proof.
-  exact thm4.
-  Print Assumptions thm4.
-Qed.
+CWGroup "Solution.thm4".
+  CWTest "should have the correct type".
+    CWAssert Solution.thm4 : (1 = 1).
+  CWTest "should be closed under the global context".
+    CWAssert Solution.thm4 Assumes.
+CWEndGroup.

--- a/examples/passing/Solution.v
+++ b/examples/passing/Solution.v
@@ -1,7 +1,1 @@
-Theorem plus_n_O : forall n:nat, n = n + 0.
-Proof.
-  intros n.
-  induction n.
-  - reflexivity.
-  - simpl. rewrite <- IHn. reflexivity.
-Qed.
+Theorem thm4 : 1 = 1. Proof. reflexivity. Qed.

--- a/examples/passing/SolutionTest.v
+++ b/examples/passing/SolutionTest.v
@@ -1,6 +1,9 @@
-Require Import Solution.
-Theorem plus_n_O_check : forall n:nat, n = n + 0.
-Proof.
-  exact plus_n_O.
-  Print Assumptions plus_n_O.
-Qed.
+Require Solution.
+From CW Require Import Loader.
+
+CWGroup "Solution.thm4".
+  CWTest "should have the correct type".
+    CWAssert Solution.thm4 : (1 = 1).
+  CWTest "should be closed under the global context".
+    CWAssert Solution.thm4 Assumes.
+CWEndGroup.


### PR DESCRIPTION
Related: codewars/runner#189

A proof of concept that uses the Coq Platform scripts to install the base package set for 2022.04.0:

- Coq 8.15.1 only + coq_codewars
- Base image is now Ubuntu Jammy (slightly larger; [way fewer headaches](http://crunchtools.com/comparison-linux-container-images/) :wink: )
- Final size: 2.08 GB
- Passing and failing examples now use `CWAssert` in coq_codewars for unit tests
- `bin/run` now accepts `CONTAINER_ENGINE` variable to specify container engine (default: `docker`). This is because I use Podman myself for development so the original `bin/run` doesn't work for me

I haven't installed the libraries from 8.12 yet (Equations, mathcomp) because I don't intend this to be the version we release on Codewars. If this proof of concept looks fine, I'd like to install the [full package set](https://github.com/coq/platform/blob/1af4a9d6fac8f681e0172855fad8805c9877e47a/doc/README~8.15~2022.04.md#coq-platform-2022040-with-coq-8151-full-level) which includes Equations, mathcomp and many other open-source libraries, which could greatly increase the variety of Coq Kata we can author on Codewars.